### PR TITLE
fix: skip extra-allow fields missing from model_fields in validation

### DIFF
--- a/src/reconcile/core.py
+++ b/src/reconcile/core.py
@@ -251,7 +251,9 @@ class ReconcileSession:
                         f"{cls.__name__}.{dep.field_name}: required but unresolved"
                     )
             for field_name in set(fields) | obj.model_fields_set:
-                fi = cls.model_fields[field_name]
+                fi = cls.model_fields.get(field_name)
+                if fi is None:
+                    continue
                 if fi.metadata:
                     ta: TypeAdapter[Any] = TypeAdapter(
                         typing.Annotated[fi.annotation, *fi.metadata]

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -445,3 +445,22 @@ class TestCircular:
         assert type(b).__name__ == "MutualB"
         assert a.value is None
         assert b.value is None
+
+
+class TestExtraFields:
+    def test_extra_allow_fields_skipped_in_validation(self):
+        """model_fields_set may contain names absent from model_fields when extra='allow'."""
+        from pydantic import ConfigDict
+
+        class Flexible(BaseModel):
+            model_config = ConfigDict(extra="allow")
+            value: int | None = Field(default=None)
+
+            @dependency(value)
+            def _(self, t: TrainingSpec) -> int:
+                return t.num_steps
+
+        obj = Flexible(decoder_start_token_id=1)
+        (obj, _) = reconcile(obj, TrainingSpec(num_steps=42))
+        assert obj.value == 42
+        assert obj.decoder_start_token_id == 1


### PR DESCRIPTION
## Summary

- `validate_fields` iterates `set(fields) | obj.model_fields_set`, but when a model uses `extra='allow'` (Pydantic's `ConfigDict(extra="allow")`), `model_fields_set` can contain field names that don't exist in `model_fields`, causing a `KeyError`
- Fix: use `model_fields.get(field_name)` with a `None` guard instead of direct dict access, matching the behavior of the original inline implementation

## Test plan

- [x] Added test `test_extra_allow_fields_skipped_in_validation` that reproduces the `KeyError` on a model with `extra='allow'` and verifies it now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)