### PR TITLE
fix: discover nested BaseModel from default_factory

### DIFF
--- a/src/reconcile/core.py
+++ b/src/reconcile/core.py
@@ -138,7 +138,7 @@ class ProviderIndex:
         queue = deque(obj for obj in all_objs if isinstance(obj, BaseModel))
         while queue:
             obj = queue.popleft()
-            for field_name in obj.model_fields_set:
+            for field_name in type(obj).model_fields:
                 value = obj.__dict__.get(field_name)
                 if isinstance(value, BaseModel) and id(value) not in seen_ids:
                     seen_ids.add(id(value))

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -313,6 +313,45 @@ class TestFeatures:
         reconcile(parallel, TrainingSpec(num_steps=100))
 
 
+    def test_default_factory_nested_discovered(self):
+        """Nested BaseModel created by default_factory should be discovered and resolved."""
+
+        class Source(BaseModel):
+            name: str = "hello"
+
+        class Inner(BaseModel):
+            value: str | None = Field(default=None)
+
+            @dependency(value)
+            def _derive(self, s: Source) -> str:
+                return s.name
+
+        class Outer(BaseModel):
+            inner: Inner = Field(default_factory=Inner)
+
+        (outer, _) = reconcile(Outer(), Source())
+        assert outer.inner.value == "hello"
+
+    def test_default_factory_nested_not_overridden(self):
+        """Explicitly set nested field should not be clobbered by discovery."""
+
+        class Source(BaseModel):
+            name: str = "hello"
+
+        class Inner(BaseModel):
+            value: str | None = Field(default=None)
+
+            @dependency(value)
+            def _derive(self, s: Source) -> str:
+                return s.name
+
+        class Outer(BaseModel):
+            inner: Inner = Field(default_factory=Inner)
+
+        (outer, _) = reconcile(Outer(inner=Inner(value="custom")), Source())
+        assert outer.inner.value == "custom"
+
+
 class TestHitchhike:
     def test_hitchhike_not_returned(self):
         training = TrainingSpec(num_steps=500)


### PR DESCRIPTION
## Problem

`_discover()` uses `model_fields_set` to walk nested `BaseModel` children, but `model_fields_set` only includes fields explicitly passed at construction time. Nested objects created by `default_factory` are never in `model_fields_set`, so their `@dependency` fields are silently skipped.

```python
class Inner(BaseModel):
    value: str | None = Field(default=None)

    @dependency(value)
    def _derive(self, s: Source) -> str:
        return s.name

class Outer(BaseModel):
    inner: Inner = Field(default_factory=Inner)

# Outer() -> inner not in model_fields_set -> Inner._derive never runs
(outer, _) = reconcile(Outer(), Source(name="hello"))
assert outer.inner.value is None  # bug: expected "hello"
```

Workaround: `Outer(inner=Inner())` — but this defeats the purpose of `default_factory`.

## Fix

Change `_discover()` to iterate `type(obj).model_fields` (all declared fields) instead of `obj.model_fields_set` (only explicitly set fields). This also avoids the Pydantic V2.11 deprecation warning for accessing `model_fields` on instances.

## Tests

- `test_default_factory_nested_discovered`: verifies the fix
- `test_default_factory_nested_not_overridden`: verifies explicit values are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了嵌套模型的发现机制，确保通过 default_factory 创建的模型能被正确识别和解析。
  * 保证显式提供的模型值不被无意覆盖。

* **Tests**
  * 增加了嵌套模型发现和解析相关的单元测试。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fecet/reconcile/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->